### PR TITLE
feat: repeat mode, bounded history, RAM optimization, and dep fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",
-		"@biomejs/biome": "^1.9.4",
 		"@types/node": "^22.13.10",
 		"@types/ws": "^8.18.0",
 		"discord.js": "^14.18.0",

--- a/src/Structures/Analytics.ts
+++ b/src/Structures/Analytics.ts
@@ -119,6 +119,10 @@ export interface AnalyticsOptions {
 	trackUsers?: boolean;
 	/** Whether to anonymize user data */
 	anonymizeUsers?: boolean;
+	/** Max number of guilds to keep analytics data for. Default: 1000 */
+	maxGuilds?: number;
+	/** How often to run old-data cleanup (in ms). Default: 3600000 (1 hour) */
+	cleanupInterval?: number;
 }
 
 /**
@@ -130,6 +134,7 @@ export class Analytics {
 	private sessions: Map<string, SessionData> = new Map();
 	private storage: StorageStrategy;
 	private saveInterval: NodeJS.Timeout | undefined = undefined;
+	private cleanupTimer: NodeJS.Timeout | undefined = undefined;
 	private options: Required<AnalyticsOptions>;
 	private trackEndListeners: Map<string, number> = new Map();
 
@@ -149,6 +154,8 @@ export class Analytics {
 			historyRetention: 30, // 30 days
 			trackUsers: true,
 			anonymizeUsers: false,
+			maxGuilds: 1000,
+			cleanupInterval: 3600000, // 1 hour
 			...options,
 		};
 
@@ -163,6 +170,11 @@ export class Analytics {
 			this.saveInterval = setInterval(() => {
 				this.saveData();
 			}, this.options.saveInterval);
+
+			// Periodic cleanup of old data
+			this.cleanupTimer = setInterval(() => {
+				this.cleanupOldData();
+			}, this.options.cleanupInterval);
 		}
 	}
 
@@ -785,12 +797,23 @@ export class Analytics {
 	public cleanupOldData(): void {
 		const cutoffDate = Date.now() - this.options.historyRetention * 24 * 60 * 60 * 1000;
 
-		// Clean up recent tracks older than cutoff
 		for (const [_guildId, analytics] of this.data.entries()) {
+			// Remove recently played tracks older than retention
 			analytics.tracks.recentlyPlayed = analytics.tracks.recentlyPlayed.filter((track) => track.playedAt >= cutoffDate);
 
-			// Update last updated timestamp
 			analytics.lastUpdated = Date.now();
+		}
+
+		// Evict stale guilds when exceeding maxGuilds limit
+		if (this.data.size > this.options.maxGuilds) {
+			const sorted = [...this.data.entries()].sort((a, b) => a[1].lastUpdated - b[1].lastUpdated);
+			const toRemove = this.data.size - this.options.maxGuilds;
+			for (let i = 0; i < toRemove; i++) {
+				const entry = sorted[i];
+				if (entry) {
+					this.data.delete(entry[0]);
+				}
+			}
 		}
 	}
 
@@ -799,6 +822,7 @@ export class Analytics {
 	 */
 	public async shutdown(): Promise<void> {
 		clearInterval(this.saveInterval);
+		clearInterval(this.cleanupTimer);
 		await this.saveData();
 	}
 }

--- a/src/Structures/Lyrics.ts
+++ b/src/Structures/Lyrics.ts
@@ -62,8 +62,12 @@ export class LyricsManager {
 	private cache: Map<string, LyricsData> = new Map();
 	/** Cache duration in ms */
 	private cacheDuration: number;
+	/** Max number of entries in the lyrics cache */
+	private maxCacheSize: number;
 	/** Reference to the LithiumX manager */
 	private manager: LithiumXManager;
+	/** Periodic cache cleanup timer */
+	private cleanupTimer: NodeJS.Timeout | undefined;
 
 	/**
 	 * Create a new lyrics manager
@@ -73,6 +77,7 @@ export class LyricsManager {
 	constructor(manager: LithiumXManager, options: LyricsManagerOptions = {}) {
 		this.manager = manager;
 		this.cacheDuration = options.cacheDuration || 3600000; // Default: 1 hour
+		this.maxCacheSize = options.maxCacheSize ?? 200;
 
 		// Register default providers
 		this.registerProvider(new DefaultLyricsProvider());
@@ -90,7 +95,7 @@ export class LyricsManager {
 
 		// Clean cache periodically
 		if (this.cacheDuration > 0) {
-			setInterval(() => this.cleanCache(), this.cacheDuration);
+			this.cleanupTimer = setInterval(() => this.cleanCache(), this.cacheDuration);
 		}
 	}
 
@@ -135,7 +140,7 @@ export class LyricsManager {
 			try {
 				const lyrics = await provider.fetch(track, options);
 				if (lyrics?.lyrics) {
-					// Cache the result
+					this.evictIfNeeded();
 					this.cache.set(cacheKey, lyrics);
 					return lyrics;
 				}
@@ -167,6 +172,7 @@ export class LyricsManager {
 		try {
 			const lyrics = await provider.fetch(track, options);
 			if (lyrics?.lyrics) {
+				this.evictIfNeeded();
 				this.cache.set(cacheKey, lyrics);
 				return lyrics;
 			}
@@ -188,8 +194,19 @@ export class LyricsManager {
 	 * Remove expired cache entries
 	 */
 	private cleanCache(): void {
-		// Simple implementation - just clear all cache
-		this.clearCache();
+		this.cache.clear();
+	}
+
+	/**
+	 * Evict oldest entry when cache exceeds max size
+	 */
+	private evictIfNeeded(): void {
+		if (this.cache.size >= this.maxCacheSize) {
+			const oldestKey = this.cache.keys().next();
+			if (!oldestKey.done && oldestKey.value !== undefined) {
+				this.cache.delete(oldestKey.value);
+			}
+		}
 	}
 }
 
@@ -199,6 +216,8 @@ export class LyricsManager {
 export interface LyricsManagerOptions {
 	/** How long to cache lyrics (in milliseconds) */
 	cacheDuration?: number;
+	/** Max number of entries in the lyrics cache. Default: 200 */
+	maxCacheSize?: number;
 	/** Genius API key for using the Genius lyrics provider */
 	geniusApiKey?: string;
 	/** Additional lyrics providers to register */

--- a/src/Structures/Manager.ts
+++ b/src/Structures/Manager.ts
@@ -144,6 +144,8 @@ class LithiumXManager extends TypedEmitter<ManagerEvents> {
 			...options,
 		};
 
+		this.options.caches.maxSize ??= 100;
+
 		if (this.options.plugins) {
 			for (const [index, plugin] of this.options.plugins.entries()) {
 				if (!(plugin instanceof Plugin)) throw new RangeError(`Plugin at index ${index} does not extend Plugin.`);
@@ -305,6 +307,10 @@ class LithiumXManager extends TypedEmitter<ManagerEvents> {
 				}
 			}
 			if (this.options.caches.enabled && this.options.caches.time > 0) {
+				if (this.caches.size >= (this.options.caches.maxSize ?? 100)) {
+					const oldestKey = this.caches.firstKey();
+					if (oldestKey) this.caches.delete(oldestKey);
+				}
 				this.caches.set(search, { result, expiresAt: Date.now() + this.options.caches.time });
 			}
 			return result;
@@ -493,8 +499,10 @@ interface ManagerOptions {
 	caches: {
 		/** Whether to cache the search results. */
 		enabled: boolean;
-		/** The time to cache the search results. */
+		/** The time to cache the search results (in ms). */
 		time: number;
+		/** Max number of entries in the search cache. Default: 100 */
+		maxSize?: number;
 	};
 	/** Lyrics configuration */
 	lyrics?: {

--- a/src/Structures/Node.ts
+++ b/src/Structures/Node.ts
@@ -708,8 +708,9 @@ class LithiumXNode {
 					}
 
 					player.setVolume(data.volume);
-					player.queueRepeat = data.queueRepeat;
-					player.trackRepeat = data.trackRepeat;
+					if (data.trackRepeat) player.setRepeatMode(RepeatMode.Track);
+					else if (data.queueRepeat) player.setRepeatMode(RepeatMode.Queue);
+					else player.setRepeatMode(RepeatMode.None);
 					player.isAutoplay = data.isAutoplay;
 
 					// If there was a current track, attempt to play it from the position

--- a/src/Structures/Node.ts
+++ b/src/Structures/Node.ts
@@ -5,6 +5,7 @@ import nodeCheck from '../Utils/NodeCheck';
 import type { LavalinkResponse, LithiumXManager, PlaylistRawData } from './Manager';
 import type { LithiumXPlayer, Track, UnresolvedTrack } from './Player';
 import { LithiumXRest } from './Rest';
+import { RepeatMode } from './Queue';
 import { type PlayerEvent, type PlayerEvents, type TrackEndEvent, type TrackExceptionEvent, type TrackStartEvent, type TrackStuckEvent, TrackUtils, type WebSocketClosedEvent } from './Utils';
 
 // Storage strategy interface
@@ -418,10 +419,10 @@ class LithiumXNode {
 		// If the track was forcibly replaced
 		else if (reason === 'replaced') {
 			this.manager.emit('TrackEnd', player, track, payload);
-			player.queue.previous = player.queue.current;
+			if (player.queue.current) player.queue.pushHistory(player.queue.current);
 		}
 		// If the track ended and it's set to repeat (track or queue)
-		else if (track && (player.trackRepeat || player.queueRepeat)) {
+		else if (track && player.queue.repeatMode !== RepeatMode.None) {
 			this.handleRepeatedTrack(player, track, payload);
 		}
 		// If there's another track in the queue
@@ -540,7 +541,7 @@ class LithiumXNode {
 
 	// Handle the case when a track failed to load or was cleaned up
 	private handleFailedTrack(player: LithiumXPlayer, track: Track, payload: TrackEndEvent): void {
-		player.queue.previous = player.queue.current;
+		if (player.queue.current) player.queue.pushHistory(player.queue.current);
 		player.queue.current = player.queue.shift() ?? null;
 
 		if (!player.queue.current) {
@@ -554,16 +555,16 @@ class LithiumXNode {
 
 	// Handle the case when a track ended and it's set to repeat (track or queue)
 	private handleRepeatedTrack(player: LithiumXPlayer, track: Track, payload: TrackEndEvent): void {
-		const { queue, trackRepeat, queueRepeat } = player;
+		const { queue } = player;
 		const { autoPlay } = this.manager.options;
 
-		if (trackRepeat) {
+		if (queue.repeatMode === RepeatMode.Track) {
 			if (queue.current) queue.unshift(queue.current);
-		} else if (queueRepeat) {
+		} else if (queue.repeatMode === RepeatMode.Queue) {
 			if (queue.current) queue.add(queue.current);
 		}
 
-		queue.previous = queue.current;
+		if (queue.current) queue.pushHistory(queue.current);
 		queue.current = queue.shift() ?? null;
 
 		this.manager.emit('TrackEnd', player, track, payload);
@@ -578,7 +579,7 @@ class LithiumXNode {
 
 	// Handle the case when there's another track in the queue
 	private playNextTrack(player: LithiumXPlayer, track: Track, payload: TrackEndEvent): void {
-		player.queue.previous = player.queue.current;
+		if (player.queue.current) player.queue.pushHistory(player.queue.current);
 		player.queue.current = player.queue.shift() ?? null;
 
 		this.manager.emit('TrackEnd', player, track, payload);
@@ -587,12 +588,10 @@ class LithiumXNode {
 	}
 
 	protected async queueEnd(player: LithiumXPlayer, track: Track, payload: TrackEndEvent): Promise<void> {
-		player.queue.previous = player.queue.current;
+		if (player.queue.current) player.queue.pushHistory(player.queue.current);
 		player.queue.current = null;
 
 		if (!player.isAutoplay) {
-			player.queue.previous = player.queue.current;
-			player.queue.current = null;
 			player.playing = false;
 			this.manager.emit('QueueEnd', player, track, payload);
 			return;

--- a/src/Structures/Player.ts
+++ b/src/Structures/Player.ts
@@ -3,7 +3,7 @@ import { type FilterOptions, FilterPresets, Filters } from './Filters';
 import type { LyricsData, LyricsOptions } from './Lyrics';
 import type { LavalinkResponse, LithiumXManager, PlaylistRawData, SearchQuery, SearchResult } from './Manager';
 import type { LavalinkInfo, LithiumXNode } from './Node';
-import { LithiumXQueue } from './Queue';
+import { LithiumXQueue, RepeatMode } from './Queue';
 import type { LoadQueueOptions, QueueOperationResult, SaveQueueOptions } from './QueueManager';
 import { type Sizes, type State, type TrackExceptionEvent, type TrackSourceName, TrackUtils, type VoiceState } from './Utils';
 
@@ -417,18 +417,7 @@ export class LithiumXPlayer {
 	 */
 	public setTrackRepeat(repeat: boolean): this {
 		if (typeof repeat !== 'boolean') throw new TypeError('Repeat can only be "true" or "false".');
-		const oldPlayer = { ...this };
-		if (repeat) {
-			this.trackRepeat = true;
-			this.queueRepeat = false;
-			this.dynamicRepeat = false;
-		} else {
-			this.trackRepeat = false;
-			this.queueRepeat = false;
-			this.dynamicRepeat = false;
-		}
-		this.manager.emit('PlayerStateUpdate', oldPlayer, this);
-		return this;
+		return this.setRepeatMode(repeat ? RepeatMode.Track : RepeatMode.None);
 	}
 
 	/**
@@ -437,19 +426,20 @@ export class LithiumXPlayer {
 	 */
 	public setQueueRepeat(repeat: boolean): this {
 		if (typeof repeat !== 'boolean') throw new TypeError('Repeat can only be "true" or "false".');
+		return this.setRepeatMode(repeat ? RepeatMode.Queue : RepeatMode.None);
+	}
 
+	/**
+	 * Sets the repeat mode for the queue.
+	 * @param mode The RepeatMode to apply.
+	 */
+	public setRepeatMode(mode: RepeatMode): this {
 		const oldPlayer = { ...this };
-
-		if (repeat) {
-			this.trackRepeat = false;
-			this.queueRepeat = true;
-			this.dynamicRepeat = false;
-		} else {
-			this.trackRepeat = false;
-			this.queueRepeat = false;
-			this.dynamicRepeat = false;
-		}
-
+		this.queue.repeatMode = mode;
+		this.trackRepeat  = mode === RepeatMode.Track;
+		this.queueRepeat  = mode === RepeatMode.Queue;
+		this.dynamicRepeat = false;
+		if (this.dynamicLoopInterval) clearInterval(this.dynamicLoopInterval);
 		this.manager.emit('PlayerStateUpdate', oldPlayer, this);
 		return this;
 	}
@@ -474,6 +464,7 @@ export class LithiumXPlayer {
 			this.trackRepeat = false;
 			this.queueRepeat = false;
 			this.dynamicRepeat = true;
+			this.queue.repeatMode = RepeatMode.None;
 
 			this.dynamicLoopInterval = setInterval(() => {
 				if (!this.dynamicRepeat) return;
@@ -488,6 +479,7 @@ export class LithiumXPlayer {
 			this.trackRepeat = false;
 			this.queueRepeat = false;
 			this.dynamicRepeat = false;
+			this.queue.repeatMode = RepeatMode.None;
 		}
 
 		this.manager.emit('PlayerStateUpdate', oldPlayer, this);

--- a/src/Structures/Player.ts
+++ b/src/Structures/Player.ts
@@ -544,11 +544,9 @@ export class LithiumXPlayer {
 
 	/** Go back to the previous song. */
 	public previous(): this {
-		if (this.queue.previous) {
-			this.queue.unshift(this.queue.previous);
-		}
+		const prev = this.queue.popHistory();
+		if (prev) this.queue.unshift(prev);
 		this.stop();
-
 		return this;
 	}
 

--- a/src/Structures/Player.ts
+++ b/src/Structures/Player.ts
@@ -271,7 +271,7 @@ export class LithiumXPlayer {
 	public async play(track: Track | UnresolvedTrack, options: PlayOptions): Promise<void>;
 	public async play(optionsOrTrack?: PlayOptions | Track | UnresolvedTrack, playOptions?: PlayOptions): Promise<void> {
 		if (typeof optionsOrTrack !== 'undefined' && TrackUtils.validate(optionsOrTrack)) {
-			if (this.queue.current) this.queue.previous = this.queue.current;
+			if (this.queue.current) this.queue.pushHistory(this.queue.current);
 			this.queue.current = optionsOrTrack as Track;
 		}
 		if (!this.queue.current) throw new RangeError('No current track.');

--- a/src/Structures/Queue.ts
+++ b/src/Structures/Queue.ts
@@ -40,7 +40,7 @@ export class LithiumXQueue extends Array<Track | UnresolvedTrack> {
 
 	public pushHistory(track: Track | UnresolvedTrack): void {
 		this.history.unshift(track);
-		if (this.history.length > this.maxHistorySize) this.history.pop();
+		if (this.history.length > Math.max(0, this.maxHistorySize)) this.history.pop();
 	}
 
 	public popHistory(): Track | UnresolvedTrack | null {

--- a/src/Structures/Queue.ts
+++ b/src/Structures/Queue.ts
@@ -1,6 +1,12 @@
 import type { Track, UnresolvedTrack } from './Player';
 import { TrackUtils } from './Utils';
 
+export enum RepeatMode {
+  None  = 'none',
+  Track = 'track',
+  Queue = 'queue',
+}
+
 /**
  * The player's queue, the `current` property is the currently playing track, think of the rest as the up-coming tracks.
  */
@@ -24,8 +30,22 @@ export class LithiumXQueue extends Array<Track | UnresolvedTrack> {
 	/** The current track */
 	public current: Track | UnresolvedTrack | null = null;
 
-	/** The previous track */
-	public previous: Track | UnresolvedTrack | null = null;
+	public repeatMode: RepeatMode = RepeatMode.None;
+	public history: (Track | UnresolvedTrack)[] = [];
+	public maxHistorySize: number = 50;
+
+	public get previous(): Track | UnresolvedTrack | null {
+		return this.history[0] ?? null;
+	}
+
+	public pushHistory(track: Track | UnresolvedTrack): void {
+		this.history.unshift(track);
+		if (this.history.length > this.maxHistorySize) this.history.pop();
+	}
+
+	public popHistory(): Track | UnresolvedTrack | null {
+		return this.history.shift() ?? null;
+	}
 
 	/**
 	 * Adds a track to the queue.

--- a/tests/unit/player-repeat.test.ts
+++ b/tests/unit/player-repeat.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LithiumXPlayer } from '../../src/Structures/Player';
+import { RepeatMode } from '../../src/Structures/Queue';
+import { createTestManager } from '../helpers';
+
+function createMockPlayer(): LithiumXPlayer {
+  const manager = createTestManager();
+  return manager.create({
+    guild: '111111111111111111',
+    voiceChannel: '222222222222222222',
+  });
+}
+
+describe('LithiumXPlayer.setRepeatMode()', () => {
+  let player: LithiumXPlayer;
+  beforeEach(() => { player = createMockPlayer(); });
+
+  it('sets queue.repeatMode to the given mode', () => {
+    player.setRepeatMode(RepeatMode.Track);
+    expect(player.queue.repeatMode).toBe(RepeatMode.Track);
+  });
+
+  it('sets trackRepeat=true when mode is Track', () => {
+    player.setRepeatMode(RepeatMode.Track);
+    expect(player.trackRepeat).toBe(true);
+    expect(player.queueRepeat).toBe(false);
+  });
+
+  it('sets queueRepeat=true when mode is Queue', () => {
+    player.setRepeatMode(RepeatMode.Queue);
+    expect(player.queueRepeat).toBe(true);
+    expect(player.trackRepeat).toBe(false);
+  });
+
+  it('clears both flags when mode is None', () => {
+    player.setRepeatMode(RepeatMode.Track);
+    player.setRepeatMode(RepeatMode.None);
+    expect(player.trackRepeat).toBe(false);
+    expect(player.queueRepeat).toBe(false);
+    expect(player.queue.repeatMode).toBe(RepeatMode.None);
+  });
+
+  it('emits PlayerStateUpdate', () => {
+    const emitSpy = vi.spyOn(player.manager, 'emit');
+    player.setRepeatMode(RepeatMode.Queue);
+    expect(emitSpy).toHaveBeenCalledWith('PlayerStateUpdate', expect.anything(), player);
+  });
+});
+
+describe('setTrackRepeat delegates to setRepeatMode', () => {
+  let player: LithiumXPlayer;
+  beforeEach(() => { player = createMockPlayer(); });
+
+  it('setTrackRepeat(true) sets queue.repeatMode = Track', () => {
+    player.setTrackRepeat(true);
+    expect(player.queue.repeatMode).toBe(RepeatMode.Track);
+  });
+
+  it('setTrackRepeat(false) sets queue.repeatMode = None', () => {
+    player.setTrackRepeat(true);
+    player.setTrackRepeat(false);
+    expect(player.queue.repeatMode).toBe(RepeatMode.None);
+  });
+});
+
+describe('setQueueRepeat delegates to setRepeatMode', () => {
+  let player: LithiumXPlayer;
+  beforeEach(() => { player = createMockPlayer(); });
+
+  it('setQueueRepeat(true) sets queue.repeatMode = Queue', () => {
+    player.setQueueRepeat(true);
+    expect(player.queue.repeatMode).toBe(RepeatMode.Queue);
+  });
+
+  it('setQueueRepeat(false) sets queue.repeatMode = None', () => {
+    player.setQueueRepeat(true);
+    player.setQueueRepeat(false);
+    expect(player.queue.repeatMode).toBe(RepeatMode.None);
+  });
+});

--- a/tests/unit/queue-history.test.ts
+++ b/tests/unit/queue-history.test.ts
@@ -88,3 +88,16 @@ describe('LithiumXQueue history size limit', () => {
     expect(queue.maxHistorySize).toBe(50);
   });
 });
+
+describe('LithiumXQueue.popHistory multi-step', () => {
+  it('allows stepping back through multiple entries', () => {
+    const queue = new LithiumXQueue();
+    const tracks = ['a', 'b', 'c'].map(t => ({ title: t } as unknown as Track));
+    for (const t of tracks) queue.pushHistory(t);
+    // history is [c, b, a]
+    expect(queue.popHistory()?.title).toBe('c');
+    expect(queue.popHistory()?.title).toBe('b');
+    expect(queue.popHistory()?.title).toBe('a');
+    expect(queue.popHistory()).toBeNull();
+  });
+});

--- a/tests/unit/queue-history.test.ts
+++ b/tests/unit/queue-history.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { LithiumXQueue, RepeatMode } from '../../src/Structures/Queue';
+import type { Track } from '../../src/Structures/Player';
+
+function makeTrack(title: string): Track {
+  return { title, uri: `https://example.com/${title}`, duration: 180000 } as unknown as Track;
+}
+
+describe('RepeatMode enum', () => {
+  it('exports None, Track, Queue values', () => {
+    expect(RepeatMode.None).toBe('none');
+    expect(RepeatMode.Track).toBe('track');
+    expect(RepeatMode.Queue).toBe('queue');
+  });
+});
+
+describe('LithiumXQueue.repeatMode', () => {
+  let queue: LithiumXQueue;
+  beforeEach(() => { queue = new LithiumXQueue(); });
+
+  it('defaults to RepeatMode.None', () => {
+    expect(queue.repeatMode).toBe(RepeatMode.None);
+  });
+
+  it('can be set to any RepeatMode value', () => {
+    queue.repeatMode = RepeatMode.Track;
+    expect(queue.repeatMode).toBe(RepeatMode.Track);
+    queue.repeatMode = RepeatMode.Queue;
+    expect(queue.repeatMode).toBe(RepeatMode.Queue);
+    queue.repeatMode = RepeatMode.None;
+    expect(queue.repeatMode).toBe(RepeatMode.None);
+  });
+});
+
+describe('LithiumXQueue.history', () => {
+  let queue: LithiumXQueue;
+  beforeEach(() => { queue = new LithiumXQueue(); });
+
+  it('starts empty', () => {
+    expect(queue.history).toEqual([]);
+  });
+
+  it('pushHistory prepends track to history', () => {
+    const t1 = makeTrack('a');
+    const t2 = makeTrack('b');
+    queue.pushHistory(t1);
+    queue.pushHistory(t2);
+    expect(queue.history[0]).toBe(t2);
+    expect(queue.history[1]).toBe(t1);
+  });
+
+  it('popHistory removes and returns the most recent entry', () => {
+    const t1 = makeTrack('a');
+    const t2 = makeTrack('b');
+    queue.pushHistory(t1);
+    queue.pushHistory(t2);
+    expect(queue.popHistory()).toBe(t2);
+    expect(queue.history).toHaveLength(1);
+    expect(queue.history[0]).toBe(t1);
+  });
+
+  it('popHistory returns null when history is empty', () => {
+    expect(queue.popHistory()).toBeNull();
+  });
+
+  it('previous getter returns history[0] or null', () => {
+    expect(queue.previous).toBeNull();
+    const t = makeTrack('x');
+    queue.pushHistory(t);
+    expect(queue.previous).toBe(t);
+  });
+});
+
+describe('LithiumXQueue history size limit', () => {
+  it('evicts oldest entry when history exceeds maxHistorySize', () => {
+    const queue = new LithiumXQueue();
+    queue.maxHistorySize = 3;
+    const tracks = ['a', 'b', 'c', 'd'].map(makeTrack);
+    for (const t of tracks) queue.pushHistory(t);
+    expect(queue.history).toHaveLength(3);
+    expect(queue.history[0]).toBe(tracks[3]); // d
+    expect(queue.history[1]).toBe(tracks[2]); // c
+    expect(queue.history[2]).toBe(tracks[1]); // b
+  });
+
+  it('default maxHistorySize is 50', () => {
+    const queue = new LithiumXQueue();
+    expect(queue.maxHistorySize).toBe(50);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `RepeatMode` enum and bounded history array to queue
- Add `setRepeatMode()` and `previous()` with full history traversal to player
- Sync `queue.repeatMode` during session restore via `setRepeatMode()`
- RAM optimization: bounded caches and analytics cleanup
- Fix duplicate `@biomejs/biome` dev dependency in package.json

## Test plan
- [ ] Verify repeat modes (off/track/queue) cycle correctly
- [ ] Verify `previous()` traverses full playback history
- [ ] Verify session restore preserves repeat mode
- [ ] Verify `bun install` resolves without duplicate dep error